### PR TITLE
Update URL to download the .sif container

### DIFF
--- a/source/data/install.sh
+++ b/source/data/install.sh
@@ -4,5 +4,5 @@ echo "Downloading TractoFlow..."
 nextflow pull scilus/tractoflow
 echo "Done: TractoFlow downloaded."
 echo "Downloading TractoFlow Singularity..."
-wget -q --show-progress http://scil.usherbrooke.ca/containers_list/scilus_1.4.2.sif
+wget -q --show-progress https://scil.usherbrooke.ca/containers/scilus_1.4.2.sif
 echo "Done: TractoFlow Singularity downloaded."

--- a/source/installation/install.rst
+++ b/source/installation/install.rst
@@ -56,7 +56,7 @@ Download the last release of the Singularity container for TractoFlow:
 
 ::
 
-    $> wget http://scil.usherbrooke.ca/containers_list/scilus_1.4.2.sif
+    $> wget https://scil.usherbrooke.ca/containers/scilus_1.4.2.sif
 
 Or if you have sudo privileges
 


### PR DESCRIPTION
Former URL returns `ERROR 404: Not Found`. 
Dug a bit to find out `containers_list` needed to be replaced by `containers`, ie, https://scil.usherbrooke.ca/containers/scilus_1.4.2.sif.  